### PR TITLE
Checklist environment

### DIFF
--- a/chapters/categories.tex
+++ b/chapters/categories.tex
@@ -12,7 +12,7 @@ We start with the standard example of a category: the category of sets $\cSet$. 
 Given two objects $A,B : \Set$ we define the set of morphisms which in this case is the set of functions, $\cSet(A,B) = A \to B$. For every object $A : \Set$ we have an identity function $\id_A : A \to A$ which is defined as $\id_A\,a = a$, given functions $f : B \to C$ and $g : A \to B$ we define function composition $f \circ g : A \to C$ as $(f\circ g)\,a = f\,(g\,a)$. The strange order of arguments in composition is a consequence of the fact that we write function application this way around, hence there is no change of direction in the definition of $\circ$. We observe that there are a number of laws for function composition: identity is neutral, that is given $f : A \to B$ we have that $\id_B \circ f = f$ and $f \circ \id_A = f$ and moreover it is associative, that is given three composable function $h : C \to D, g : B \to C, f : A \to B$ we have that $h \circ (g \circ f) = (h \circ g) \circ f$.
 
 
-\begin{exercise}
+\begin{exercise}{setCategoryLaws}
   Write down the proofs that identity is neutral and composition is associative in detail.
 \end{exercise}
 \begin{answer}
@@ -48,7 +48,7 @@ We abstract from this example to define what is a category: A category $\cat{C}$
 %Inspired by the set example we also write $A \to_{\cat{C}} B$ for this.
 For every object $A : \obj{\cat{C}}$ we have an identity function%
 \footnote{We are overloading $\id$ and $\circ$ to be precise we should annotate these symbols with the category, i.e. write $\id^{\cat{C}}$ and $\circ^{\cat{C}}$. However, it is usually clear from the context which category is meant.}
-$\id_A : \homC{C}{A}{A}$, given functions $f : \homC{C}{B}{C}$ and $g : \homC{C}{A}{B}$ there is a composite $f \circ g : \homC{C}{A}{C}$ satisfying the following laws: identity is neutral, that is given $f : \cat{C}(A,B)$ we have that $\id_B \circ f = f$ and $f \circ \id_A = f$ and moreover it is associative, that is given three composable functions $f : \homC{C}{A}{B}, g : \homC{C}{B}{C}, h : \homC{C}{C}{D}$ we have that $h \circ (g \circ h) = (h \circ g) \circ f$. Whenever we want to define a new category, we have to supply all these components (summarised in \checklistref{Category}).
+$\id_A : \homC{C}{A}{A}$, given functions $f : \homC{C}{B}{C}$ and $g : \homC{C}{A}{B}$ there is a composite $f \circ g : \homC{C}{A}{C}$ satisfying the following laws: identity is neutral, that is given $f : \cat{C}(A,B)$ we have that $\id_B \circ f = f$ and $f \circ \id_A = f$ and moreover it is associative, that is given three composable functions $f : \homC{C}{A}{B}, g : \homC{C}{B}{C}, h : \homC{C}{C}{D}$ we have that $h \circ (g \circ h) = (h \circ g) \circ f$. Whenever we want to define a new category, we have to supply all these components (summarised in \checklistref{Category}); for instance, we do this for $\cat{Set}$ in \checklistref{Set}.
 
 \begin{NamedDoubleChecklist}[to define a category $\cat{C}$, we need to specify]{Category}{Data}{Conditions}
   \item objects
@@ -61,6 +61,18 @@ $\id_A : \homC{C}{A}{A}$, given functions $f : \homC{C}{B}{C}$ and $g : \homC{C}
   \item identity is neutral (left and right)
   \item composition is associative
 \end{NamedDoubleChecklist}
+
+\begin{DoubleChecklist}[$\cat{Set}$ is a category]{Set}
+  \item[\checked] objects: sets
+  \item[\checked] morphisms: functions
+  \item[\checked] identity morphisms: \[ \id_A\,a=a\]
+  \item[\checked] composition: \[(f\circ g)\,a = f(g(a))\]
+
+  \NextColumn
+
+  \item[\checked] identity is neutral: \autoref{setCategoryLaws}
+  \item[\checked] composition is associative: \autoref{setCategoryLaws}
+\end{DoubleChecklist}
 
 Equations in category theory are often shown as \emph{commuting diagrams}. Composition corresponds to completing a triangle 
 \[\begin{tikzcd}
@@ -107,7 +119,7 @@ We say that two objects $A,B$ are \emph{isomorphic} if there are morphisms $f : 
   A \arrow[r, bend left, "f"]  \arrow[loop left,"\id_A"] & B \arrow[l,bend left ,"g"]\arrow[loop right,"\id_B"] 
 \end{tikzcd}\]
 We call $f$ and $g$ \emph{isomorphisms}. We write $f : A \cong B$ or omitting the witness we write $A \cong B$ to express that $A$ and $B$ are isomorphic. 
-\begin{exercise}
+\begin{exercise}{inversesUnique}
   Show that inverses are unique, i.e. if $(f,g)$ and $(f,g')$ are an isomorphisms then $g = g'$. 
 \end{exercise}
 \begin{answer}
@@ -137,8 +149,8 @@ There is also a dual concept: the empty set is an \emph{initial object} $\bf{0}$
 this exists trivially because we don't have to say what the functions returns since there are no elements in its domain. In this case we are lucky there is only one way to write the initial object. We can make the symmetry precise by introducing the concept of a dual category: given a category $\cat{C}$ the opposite category $\cat{C}^\op$ has the same objects as $\cat{C}$ but the homsets are given by reversing the order $\cat{C}^\op(A,B) = \cat{C}(B,A)$ and consequently composition also reverses order $f \circ^{\cat{C}^\op} g = g \circ^{\cat{C}} f$. We can now say that an initial object is a terminal object in the opposite category, or vice versa a terminal object is an initial object in the opposite 
 category. We use the syllable \emph{co-} in this situation, we could say that an initial object is a co-terminal object or that a terminal object is a co-initial object (but nobody says this).
 
-\begin{exercise}
-  Prove explicitly that initial objects are unique upto isomorphism.
+\begin{exercise}{initObjUniq}
+  Prove explicitly that initial objects are unique up to isomorphism.
 \end{exercise}
 \begin{answer}
   This is a simple dualisation of the argument for terminal objects above. Suppose we had two initial objects $\bf{0}$ and $\bf{0'}$. Then the two triangles below commute.
@@ -156,8 +168,8 @@ When I say that a category has a terminal or initial object this also indicates 
 
 Let us look at some other examples of categories. We can use the natural numbers to define some categories: The category $\cat{\omega}$ has as objects the natural numbers and morphisms are given as $\homC{\omega}{m}{n} = m \leq n$. This is a category because $\leq$ is reflexive and transitive and those properties give rise to identity and composition. The laws hold trivial because there is at most one element of a proposition. This category is an example of a degenerate case of a category: it is a \emph{preorder}, i.e. a relation that is reflexive and transitive. 
 
-\begin{exercise}
-  Does this category have an initial or a terminal object? 
+\begin{exercise}{omegaInitTerm}
+  Does $\cat{\omega}$ have an initial or a terminal object? 
 \end{exercise}
 \begin{answer}
   It does have an initial object: 0. For all $n\colon\Nat$, we know $0\leq n$, so we get a morphism in $\homC{\omega}{0}{n}$. Since all the hom-sets are $\Prop$'s, we know that this morphism must be unique. This is an instance of a more general fact: if we view any preorder as a category (as we've done for the preorder $(\Nat,\leq)$ here), then an initial object in this category (if there is one) is a \emph{least element} in the preorder.
@@ -169,8 +181,8 @@ Let us look at some other examples of categories. We can use the natural numbers
 
 Another category we can be build from natural numbers has only one object and its morphisms are the natural numbers. The identity morphism is $0$ and composition is given by addition. The laws follow from the fact that $0$ is neutral ($n+0 = n = 0+n$) and associative $(l+m)+n = l+(m+n)$. Here we exploit the algebraic properties of $+$, namely that it is a \emph{monoid}; hence categories with one object correspond to monoids.
 
-\begin{exercise}
-  Does this category have an initial or a terminal object? 
+\begin{exercise}{NatMonoidInitTerm}
+  Does the monoid $\Nat$, considered as a one-object category, have an initial or a terminal object? 
 \end{exercise}
 \begin{answer}
   No. If an object $X$ is either initial or terminal, then this implies that $\cat{C}(X,X)$ must be the singleton set $\{\id_X\}$. But there is not one morphism from this object to itself, there are infinitely many.
@@ -178,7 +190,7 @@ Another category we can be build from natural numbers has only one object and it
 
 In Mathematics we are also interested in equivalence relations (preorders that are symmetric) and groups (monoids that have a inverses), like the integers $\Int$ with addition on negation). We can also do this for categories by saying that a category is a \emph{groupoid}, if for every morphism $f : A \to B$ there is an inverse $f^{-1} : B \to A$ such that $f \circ f^{-1} = \id$ and $f^{-1} \circ f = \id$. A groupoid whose homsets are propositions is an equivalence relation and a groupoid with one object is a group.
 
-\begin{exercise}
+\begin{exercise}{SetIsoGrpd}
   Let $\Set^{\cong}$ be the category whose objects are sets but whose morphisms are just the $\Set$-\emph{isomorphisms}. Show that this is a category, and moreover a groupoid. 
 \end{exercise}
 \begin{answer}
@@ -204,7 +216,7 @@ A rich source of categories are sets with structure. For example we define the c
 
 Another example is the category of monoids $\cat{Mon}$: Its objects are monoids, that is a set $A$ with a neutral element $e:A$ and a binary operation $\_*\_$ such that the laws of a monoid hold ($x*e=x, e*x=x, x*(y*z) = (x*y)*z$). A morphism between monoids $(A,e, \_*\_)$ and $(B,e',\_*'\_)$ is a function $f : A \to B$ which preserves the structure, i.e. $f\,e = e'$ and $f\,(x * y) = (f\,x) *' (f\, y)$. Again we only have to show that identity is a morphism and that morphisms are closed under composition to see that this is a category.
 
-\begin{exercise}
+\begin{exercise}{PreMonInitTerm}
   Do the categories $\cat{Pre}$ and $\cat{Mon}$ have initial and terminal objects?
 \end{exercise}
 \begin{answer}
@@ -242,7 +254,7 @@ On the other hand a surjective function can be cancelled on the right hand side.
 A \arrow[r,twoheadrightarrow,"e"]  & B
 \end{tikzcd}
 \]
-\begin{exercise}
+\begin{exercise}{InjMono}
   Show that the monos in $\cat{Set}$ are exactly the injective functions and the epis are exactly the surjective functions.
 % \footnote{It seems that the implication epi $\to$ surjective needs impredicativity, i.e. $\Prop_i : \Set_i$.} -- not true
 \end{exercise}
@@ -292,27 +304,24 @@ f \circ g = f \circ h
 & \implies &\id \circ g & = \id \circ h \\
 & \implies & g & = h 
 \end{align*}
-\begin{exercise}
+\begin{exercise}{sectionsAreEpic}
   Explicitly prove the dual construction: if $f : A \to B$ has a left inverse $r : B \to A$ with $f \circ r = \id$ then it is an epi.
 \end{exercise}
 Since $\half \circ \double = \id$ we can conclude that $\double$ is a mono (because it has a left inverse) and $\half$ is an epi (because it has a right inverse). On the other hand $\swap$ is self inverse that is $\swap \circ \swap = \id$ hence it has both a left and a right inverse (itself) and hence it is both a mono and an epi. 
  Indeed it is isomorphism and from the above it is easy to see that isomorphisms are always monos and epis. 
 
 In $\cat{\Set}$ the inverse direction is also true: 
-\begin{exercise}
+\begin{exercise}{BijIso}
   Show that in $\cat{\Set}$ a morphism that is both mono and epi (i.e. bijections) is an isomorphism.
 \footnote{One direction uses the principle of unique choice, that is for $R : A \to B \to \Prop$~
 \[(\forall x:A.\exists! y:B .R\,x\,y) \to \exists f :A \to B . \forall x:A.R\,x\,(f\,x) \]
 where $\exists!$ means there exists unique, i.e. $\exists! x:A.\phi\,x = \exists x:A.\phi\,x \wedge \forall y:A.\phi\,y \to x=y$. This principle is provable from univalence in Homotopy Type Theory.} 
 \end{exercise}
 However, this is not true in general: consider the embedding $i : \Nat \to \Int$, this is a monoid morphism $i : \cat{Mon}((\Nat,\_+\_,0),(\Int,\_+\_,0))$. 
-\begin{exercise}
+\begin{exercise}{epi-mono-not-iso}
   Show that $i$ is both an epi and a mono. But it cannot be an iso. Why?
 \end{exercise}
 However, if we know that the function is a mono and an epi because of inverses (we say it is a split mono and a split epi) that it is always an isomorphism:
-\begin{exercise}
-  Show that in any category a function that has both an left and a right inverse is always an isomorphism.
-\end{exercise}
 
 
 % \section{Lambda terms and substitutions}
@@ -326,7 +335,7 @@ However, if we know that the function is a mono and an epi because of inverses (
 
 % Yet another example for a category is $\cat{\Lambda}$ a category derived from simply typed $\lambda$-calculus. Here objects are contexts, that is  a sequence of typing assumptions for variables $x_0:\sigma_0,\dots,x_{n-1}:\sigma_{n-1}$ and morphisms between contexts 
 % $\Gamma$ and $\Delta = x_0:\sigma_0,\dots,x_{n-1}:\sigma_n$ are parallel substitutions of the form $x_0 \mapsto t_0, \dots x_{n-1} \mapsto t_{n-1}$ with $\Gamma \vdash t_i : \sigma_i$ for $0 \leq i < n$. 
-% \begin{exercise}
+% \begin{exercise}{}
 %   Complete the definition of this category: Define the application of a substitution of a term, that is if $\vec{t} : \cat{\Lambda}(\Gamma,\Delta)$ and $\Delta\vdash u : \sigma$ then $\Gamma \vdash u[\vec{t}] : \sigma$. Using this define composition of substitutions and define the identity substitution. Show that the laws of a category hold upto $\alpha$-conversion. If you want to avoid $\alpha$-conversion and capture-avoiding substitution use de Bruijn indices instead.
 % \end{exercise}
 

--- a/chapters/categories.tex
+++ b/chapters/categories.tex
@@ -4,10 +4,13 @@
 \section{From sets to categories}
 \label{sec:from-sets-categories}
 
+
+
 We start with the standard example of a category: the category of sets $\cSet$. To define a category we need a type of objects which is $\Set$
 %\footnote{So really we have categories of sets on every level $\cat{\Set_i}$.}%
 . We write $\obj{\cSet} = \Set$. 
 Given two objects $A,B : \Set$ we define the set of morphisms which in this case is the set of functions, $\cSet(A,B) = A \to B$. For every object $A : \Set$ we have an identity function $\id_A : A \to A$ which is defined as $\id_A\,a = a$, given functions $f : B \to C$ and $g : A \to B$ we define function composition $f \circ g : A \to C$ as $(f\circ g)\,a = f\,(g\,a)$. The strange order of arguments in composition is a consequence of the fact that we write function application this way around, hence there is no change of direction in the definition of $\circ$. We observe that there are a number of laws for function composition: identity is neutral, that is given $f : A \to B$ we have that $\id_B \circ f = f$ and $f \circ \id_A = f$ and moreover it is associative, that is given three composable function $h : C \to D, g : B \to C, f : A \to B$ we have that $h \circ (g \circ f) = (h \circ g) \circ f$.
+
 
 \begin{exercise}
   Write down the proofs that identity is neutral and composition is associative in detail.
@@ -40,13 +43,26 @@ Given two objects $A,B : \Set$ we define the set of morphisms which in this case
   so $h \circ (g \circ f) = (h \circ g) \circ f$.
 \end{answer}
 
+
 We abstract from this example to define what is a category: A category $\cat{C}$ is given by a type of objects $\obj{\cat{C}}$ and given two objects $A,B: \obj{\cat{C}}$, a set of morphisms $\homC{C}{A}{B} : \Set$ called the \emph{homset}. 
 %Inspired by the set example we also write $A \to_{\cat{C}} B$ for this.
 For every object $A : \obj{\cat{C}}$ we have an identity function%
 \footnote{We are overloading $\id$ and $\circ$ to be precise we should annotate these symbols with the category, i.e. write $\id^{\cat{C}}$ and $\circ^{\cat{C}}$. However, it is usually clear from the context which category is meant.}
-$\id_A : \homC{C}{A}{A}$, given functions $f : \homC{C}{B}{C}$ and $g : \homC{C}{A}{B}$ there is a composite $f \circ g : \homC{C}{A}{C}$ satisfying the following laws: identity is neutral, that is given $f : \cat{C}(A,B)$ we have that $\id_B \circ f = f$ and $f \circ \id_A = f$ and moreover it is associative, that is given three composable functions $f : \homC{C}{A}{B}, g : \homC{C}{B}{C}, h : \homC{C}{C}{D}$ we have that $h \circ (g \circ h) = (h \circ g) \circ f$.
+$\id_A : \homC{C}{A}{A}$, given functions $f : \homC{C}{B}{C}$ and $g : \homC{C}{A}{B}$ there is a composite $f \circ g : \homC{C}{A}{C}$ satisfying the following laws: identity is neutral, that is given $f : \cat{C}(A,B)$ we have that $\id_B \circ f = f$ and $f \circ \id_A = f$ and moreover it is associative, that is given three composable functions $f : \homC{C}{A}{B}, g : \homC{C}{B}{C}, h : \homC{C}{C}{D}$ we have that $h \circ (g \circ h) = (h \circ g) \circ f$. Whenever we want to define a new category, we have to supply all these components (summarised in \checklistref{Category}).
 
-Equations in category theory are often shown as \emph{commuting diagrams}. Composition corresponds to completing a triangle
+\begin{NamedDoubleChecklist}[to define a category $\cat{C}$, we need to specify]{Category}{Data}{Conditions}
+  \item objects
+  \item homsets (morphisms)
+  \item identity morphisms
+  \item composition
+
+  \NextColumn
+
+  \item identity is neutral (left and right)
+  \item composition is associative
+\end{NamedDoubleChecklist}
+
+Equations in category theory are often shown as \emph{commuting diagrams}. Composition corresponds to completing a triangle 
 \[\begin{tikzcd}
 A \arrow[rd, dashrightarrow,"f\circ g" below] \arrow[r,"f"] & B \arrow[d,"g"]\\
 & C

--- a/chapters/funct-natur-transf.tex
+++ b/chapters/funct-natur-transf.tex
@@ -29,7 +29,7 @@ More formally the proofs proceed by list induction.
 Inspired by $\List$ we define the notion of a functor in general: given categories $\cat{C}$ and $\cat{D}$ a functor $F : \cat{C} \to \cat{D}$ is given by a map on objects $F : \obj{\cat{C}} \to \obj{\cat{D}}$ and a map on morphisms 
 $F : \cat{C}(A,B) \to \cat{D}(F\,A,F\,B)$ that preserves identities $F\,\id_A = \id_{F\,A}$ and composition $F\,(f \circ g) = (F\,f) \circ (F\,g)$.
 
-\begin{exercise}
+\begin{exercise}{functsPreserveIsos}
   Show that every functor $F\colon\cat{C}\to\cat{D}$ preserves isomorphisms. That is if $\phi : \homC{C}{A}{B}$ is an isomorphism then so is $F\,\phi : \homC{D}{F\,A}{F\,B}$.
 \end{exercise}
 \begin{answer}
@@ -116,7 +116,7 @@ F\,B \arrow[r,"\alpha_B" below] & F\,B
 To express that $\alpha$ is a natural transformation we write:
 \[ \alpha : \int_{A : \obj{\cat{C}}} \cat{D}(F\,A,G\,A)\]
 
-\begin{exercise}
+\begin{exercise}{SetEndofunct}
 
   \Question
     Show that $\Maybe : \Set \to \Set$ where $\Maybe\,A$ is given by the constructors:
@@ -179,7 +179,7 @@ of natural transformations $\int_{X:C} \homC{D}{F\,X}{G\,X}$, the identity natur
 & (\beta \circ \alpha) : \int_{X:C} \homC{D}{F\,X}{H\,X}\\
 & (\beta \circ \alpha)_X = \beta_X \circ \alpha_X
 \end{align*}
-\begin{exercise}
+\begin{exercise}{functorCatLaws}
   Check that these are indeed natural transformations and that the laws for a category hold.
 \end{exercise}
 
@@ -191,7 +191,7 @@ An important class of functors are the forgetful functors which just \emph{forge
 Is there an interesting functor in the other direction, that is $F : \cat{\Set} \to \cat{Mon}$? Indeed there is: we can use the fact that lists form a monoid with append $\_\app\_ : \List\,A \to \List\,A \to \List\,A$ and $[] : \List\,A$, hence on objects we can define
 \[ F\,A = (\List\,A, [], \_\app\_) \]
 We have already observed that $\List$ is a functor but to show that $F$ is a functor we also need that $\List\,f$ is a monoid morphism:
-\begin{exercise}
+\begin{exercise}{ListMonoidFunct}
   Show that for any $f:A \to B$, $\List\,f : \List\,A \to \List\,B$ is a monoid morphism, that is
   \begin{align*}
     \List\,f\,[] & = [] \\
@@ -217,7 +217,7 @@ On the other hand given a function $g : A \to |M|$ we can define a function $\ps
   \psi\,g\,[] & = e \\
   \psi\,g\, [a_0,a_1,\dots,a_{n-1}] & = (g\,a_0) * (g\,a_1) * \dots * (g\,a_{n-1})
 \end{align*}
-\begin{exercise}
+\begin{exercise}{}
   Show that $\psi\,g$ is a monoid morphism, i.e. $\phi\,g : \cat{Mon}(F\,A,M)$
 \end{exercise}
 \begin{answer}
@@ -275,7 +275,7 @@ The other direction is a bit more interesting: to show that $\psi \circ \phi = \
 & = (\id\,f)\,[a_0,a_1,\dots,a_{n-1}] 
 \end{align*}
 
-\begin{exercise}
+\begin{exercise}{}
   Verify that $\phi$ is a natural transformation, that is for any $f : \cat{Set}(B,A)$ and $g:\cat{Mon}(M,N)$ the following diagram commutes:
   \[\begin{tikzcd}[row sep = large]
     \cat{Mon}(F\,A,M) \arrow[r,"\phi_{A,M}"] \arrow[d,"\lambda h. g\circ h \circ (F\,f)"] & \cat{\Set}(A,U\,M)  \arrow[d,"\lambda k. (U\,g)\circ k \circ f"] \\
@@ -324,7 +324,7 @@ In this case we say that $L$ is left adjoint to $R$ (or that $R$ is right adjoin
 
 We can actually obtain the list functor as the composition of the forgetful and the free functor: $\List = U \circ F$. We will return to this observation later, because functors which are obtained by composing a free and a forgetful functor are always monads and indeed List is a monad.
 
-\begin{exercise}
+\begin{exercise}{}
 \label{ex:free-preorder}
   There is also a forgetful functor from the category of preorders to the category of endorelations $U : \cat{Pre} \to \cat{Rel}$, which is defined just as for preorders but without any conditions, i.e. the objects are sets $X:\Set$ with a relation $R : X\to X\to\Prop$ and morphisms are defined as functions that preserve the relation (as for $\cat{Pre}$). Now $U$ doesn't do anything but it just forgets that the relation is a preorder. Can you find a left adjoint $F : \cat{Rel} \to \cat{Pre}$ which constructs the free preorder over a given relation?
 \end{exercise}
@@ -348,11 +348,11 @@ R\,B \arrow[rd,equal] \arrow[r,"\eta_{R\,B}"] &   R\,(L\,(R\,B)) \arrow[d,"R\,\e
 \end{tikzcd}
 \]
 
-\begin{exercise}
+\begin{exercise}{}
  Give explicit definitions of $\eta$ and $\epsilon$ for the adjunction between $\cat{Mon}$ and $\cat{\Set}$ we have defined.
 \end{exercise}
 
-\begin{exercise}
+\begin{exercise}{}
   Show that the two definitions of an adjunctions between two functors $L : \cat{C} \to \cat{D}$ and $R : \cat{D} \to \cat{C}$ are equivalent: 
   \begin{itemize}
   \item An adjunction is given by a natural isomorphism 
@@ -384,7 +384,7 @@ Let $F$ be a functor $\cat{C}^\op \to \cat{\Set}$ this is called \emph{a preshea
 &\homC{C}{f}{A} : \homC{C}{C}{A} \to \homC{C}{B}{A} \\
 &\homC{C}{f}{A} \,g =  g \circ f
 \end{align*}
-\begin{exercise}
+\begin{exercise}{}
   Check that $\homC{C}{\_}{A}$ satisfies the functor laws.
 \end{exercise}
 Indeed, since we already learnt that functors and natural transformations form a category, preshaves over $\cat{C}$ form a category which we denote as $\PSh\,\cat{C}$. Now using the other input of the homset of $\cat{C}$ we can form a functor $\Y : \cat{C} \to \PSh\,\cat{C}$, called the \emph{Yoneda embedding}, which is defined on objects as $\Y\,A = \homC{C}{\_}{A}$. To define the morphism part assume $f:\homC{C}{A}{B}$:
@@ -392,7 +392,7 @@ Indeed, since we already learnt that functors and natural transformations form a
 & \Y\,f :  \int_{X:\cat{C}}\homC{C}{X}{A} \to \homC{C}{X}{B} \\
 & (\Y\,f)_X\,g = f \circ g
 \end{align*}
-\begin{exercise}
+\begin{exercise}{}
   Check that $Y\,f$ is a natural transformation and that $Y$ satisfies the functor laws.
 \end{exercise}
 Maybe you wondered why presheaves are defined as contravariant functors. The reason is that this way the Yoneda embedding is covariant (otherwise it could be hardly called an embedding).
@@ -403,7 +403,7 @@ For any presheaf $F : \cat{C}^\op\to\Set$ we can use its morphism part to define
             & :  F\,X \to \int_{Y : \cat{C}} \cat{C}(Y,X) \to F\,Y \\
 \end{align*}
 as $\phi_X\,x\,f = F\,f\,x$. 
-\begin{exercise}
+\begin{exercise}{}
   Check that $\phi$ is natural in $X:\cat{C}$.
 \end{exercise}
 
@@ -458,7 +458,7 @@ Hence $(\phi \circ \psi)\,\alpha\,f = \alpha\,f$ and using extensionality we can
 .%We should also check naturality but the naturality of $\psi$ is true by construction and this is sufficient. 
 
 % This completes the proof of the Yoneda lemma, actually if we are in a really nitpicking mood we better check naturality:
-% \begin{exercise}
+% \begin{exercise}{}
 % Show the isomorphism is natural, i.e. for any $f : \cat{C}(Z,X)$
 % \[\begin{tikzcd}[row sep = large]
 %     F\,X \arrow[r,"\phi_X"] \arrow[d,"F\,f"] & \int_{Y : \cat{C}} \cat{C}(Y,X) \to F\,Y\arrow[d,"\lambda Y\,g. \alpha_Y (f \circ g)"] \\
@@ -487,7 +487,7 @@ We can expand the isomorphism further:
          & : \int_{X:\cat{C}} \homC{C}{X}{Z} \cong \int_{Y : \cat{C}} \homC{C}{Y}{X}\to \homC{C}{Y}{Z}
 \end{align*}
 We know that every functor preserves isomorphisms, a functor which is full and faithful also \emph{reflects} them. That is if $Y\,f$ is an isomorphism then $f$ is one. 
-\begin{exercise}
+\begin{exercise}{}
   Proof that every full and faithful functor reflects isomorphisms. 
 \end{exercise}
 This gives rise to a useful corollary: to show that $f : \homC{C}{A}{B}$ is an isomorphism it is enough to show that $\Y\,A$ and $\Y\,B$ are naturally isomorphic, i.e.
@@ -498,7 +498,7 @@ Sometimes we need the Yoneda lemma for covariant functors but this is no problem
 \[ \int_{X:\cat{C}} \homC{C}{X}{A} \cong \homC{C}{X}{B}. \]
 
 % Maybe you are puzzled why we use contravariant functors $\cat{C}^\op \to \cat{\Set}$, i.e. presheaves, and not just $\cat{C} \to \cat{\Set}$. This is completely equivalent because  $\cat{C} \to \Set$ becasue all we need to do is to apply the Yoneda lemma for presheaves to the opposite of our category. Still this is a nice (even though easy) exercise:
-% \begin{exercise}
+% \begin{exercise}{}
 %   Explicitely prove the Yoneda lemma for covariant presheaves $F: \cat{C} \to \cat{\Set}$:
 %   \[F\,X \cong \int_{Y : \cat{C}} \cat{C}(X,Y) \to F\,Y\] 
 % \end{exercise}
@@ -508,7 +508,7 @@ Sometimes we need the Yoneda lemma for covariant functors but this is no problem
 % \Y\,A = \lambda X.\cat{C}(X,A)
 % \end{align*}
 % This functor embeds a category into its category of presheaves and it has a number of interesting and useful properties (it is the unit of a higher adjunction) and this makes only sense if it is covariant but then presheaves have to be contravariant.
-% \begin{exercise}
+% \begin{exercise}{}
 %   Define explicitely the category of presheaves $\PSh\,\cat{C}$ and the Yoneda embedding $\Y: \cat{C} \to \PSh\,\cat{C}$ and check all the laws.
 % \end{exercise}
 
@@ -517,7 +517,7 @@ Sometimes we need the Yoneda lemma for covariant functors but this is no problem
 
 Since I have introduced the notation $\int_{A : \obj{\cat{C}}} \cat{D}(F\,A,G\,A)$ to define natural transformations, you are maybe wondering what the general meaning of these \emph{integrals} are. It is clear that $\cat{D}(F\,A,G\,A)$ is an function from
 $\obj{\cat{C}}$ but it is neither co- nor contravariant. However, it is a profunctor that is a functor of the type $F : \cat{C}^\op\times\cat{C} \to \cat{\Set}$\footnote{Here $\cat{C}\times\cat{D}$ is the product of categories: the objects are pairs of objects: $\obj{\cat{C}\times\cat{D}}=\obj{\cat{C}}\times\obj{\cat{D}}$ and the morphisms are pairs of morphisms: $\homC{C \times D}{(C_0,D_0)}{(C_1,D_1)}=\homC{C}{C_0}{C_1}\times\homC{D}{D_0}{D_1}$.} where we define it as $F(A^{-},A^{+})= \cat{D}(F\,A^{-},G\,A^{+})$.
-\begin{exercise}
+\begin{exercise}{}
   Fill in the morphism part of $F$.
 \end{exercise}
 Now given a profunctor $F : \cat{C}^\op\times\cat{C} \to \Set$ we define its end $\int_{X: \cat{C}}F(X,X)$ as a subset of the dependent function type $\alpha:\Pi_{X : \obj{\cat{C}}}F(X,X)$ such the following diagram commutes for any $f : \homC{C}{A}{B}$ in $\cat{Set}$:
@@ -530,7 +530,7 @@ Now given a profunctor $F : \cat{C}^\op\times\cat{C} \to \Set$ we define its end
 That is we define
 \[ \int_{X:\cat{C}} F(X,X) = \{ \alpha : \Pi_{X : \obj{\cat{C}}}F(X,X) \mid
   \forall {f : \homC{C}{A}{B}} . F(A,f)\,\alpha_A) = F(f,B)\,\alpha_B \}\]
-\begin{exercise}
+\begin{exercise}{}
   Show that instantiating the definition of ends given here gives rise to the definition of natural transformations given previously.
   That is $\int_{A : \obj{\cat{C}}} \cat{D}(F\,A,G\,A)$ is the set of natural transformations.
 \end{exercise}

--- a/chapters/init-algebr-term.tex
+++ b/chapters/init-algebr-term.tex
@@ -71,7 +71,7 @@ We can derive the addition function exploiting also cartesian closure. We choose
 & s\,f\,n = \suc\,(f\,n)
 \end{align*}
 We can now define $\_+\_ = \It_{\Nat\to\Nat}\,z\,s : \Nat \to (\Nat \to \Nat)$.
-\begin{exercise}
+\begin{exercise}{}
   Convince yourself that this computes the same function as the previous definition of $\_+\_$ using pattern maching.
 \end{exercise}
 
@@ -84,7 +84,7 @@ We can prove that $n + 0 = 0$ using the unicity of $\It$ instead of induction. W
 \end{tikzcd}\]  
 And hence by uniqueness $\id_\Nat = \_+0$, by applying both sides to $n:\Nat$ we obtain 
 $n = \id\,n = (\_ + 0)\,n = n + 0$. 
-\begin{exercise}
+\begin{exercise}{}
   Verify the claim that both functions make the diagram commute.
 \end{exercise}
 
@@ -101,7 +101,7 @@ However, we cannot translate this definition directly into an application of $\I
 \pred\,(\suc\,n) & = \case{\inj_2\,0}{\inj_2 \circ \suc}
 \end{align*}
 The idea is that the 2nd definition computes the predeccessor by delaying the constructors by one step.
-\begin{exercise}
+\begin{exercise}{}
 Verify in detail that both definitions of $\pred$ compute the same function.                     
 \end{exercise}
 The second definition can be translated into 
@@ -116,7 +116,7 @@ $\pred$ is the inverse of the constructors $0$ and $\suc$. We can make this prec
 & \inn = \case{0}{\suc} 
 \end{align*}
 This is an instance of Lambek's lemma which we will verify in the general case later. 
-\begin{exercise}
+\begin{exercise}{}
   Prove by induction or by using initiality that $\pred$ and $\inn$ are an isomorphism, i.e.
   \begin{align*}
     \pred \circ \inn & = \id_{1+\Nat} \\
@@ -144,7 +144,7 @@ T\,B \arrow[r,"g"] & B \\
 \end{tikzcd}\]  
 Identity and composition is given by identity and composition in $\cat{C}$, it is easy to see that the corresponding diagrams commute. 
 
-\begin{exercise}
+\begin{exercise}{}
 Show that $\Nat$ is the initial $T_\Nat$ algebra with $T_\Nat : \Set \to \Set$ defined as $T_\Nat\,X = 1+X$. 
 \end{exercise}
 
@@ -163,14 +163,14 @@ and then merging them into one function using coproducts:
 1 + A \times \List\,A & \to \List\,A
 \end{align*}
 Hence $\List\,A$ is the initial algebra of the functor $T_{\List\,A}:\cat{\Set} \to \cat{\Set}$ with $T_{\List\,A}\,X = 1 + A \times X$.
-\begin{exercise}
+\begin{exercise}{}
 Define the function $\rev_A : \List\,A \to \List\,A$ using only the iterator. \emph{Hint:} it is useful to define an auxilliary function 
 $\mathrm{snoc} : A \times\List\,A \to A$ that appends a single element at the end of a list using the iterator. 
 
 Show that this function is idempotent, that is $\rev_A \circ \rev_A = \id_{\List\,A}$ using only initiality. 
 \end{exercise}
 
-\begin{exercise}
+\begin{exercise}{}
 What are the functors defining 
 \begin{enumerate}
 \item unlabelled binary trees,
@@ -186,7 +186,7 @@ Since we already know that $\List$ is a functor, what is the initial algebra of 
 Indeed, this is the type of finitely branching trees, that is any node has a list of subtrees. We don't need to include leaves explicitely because we can have a node with an empty list of subtrees. This type is also called \emph{rose trees}.
 
 We can also construct infinitely branching trees which are the initial algebra of the functor $T\,X = 1 + \Nat \to X$. Here a node is given by a function that assigns to every natural number a subtree. This raises the question wether every functor on sets should have an initial algebra. We note that obviously paradoxical cases like $T\,X = X \to X$ are ruled out because they don't give rise to a functor. However, depending on our foundations even positive hence functorial definitions like $T\,X = (X \to \Bool) \to \Bool$ are problematic. If we work in a classical setting then this is obviously paradoxical because it gives us a fixpoint of the double powerset functor and from this we can derive a contradiction using diagonalisation.
-\begin{exercise}
+\begin{exercise}{}
 Show that having an initial algebra of $T : \Set \to \Set$ with $T\,X = (X \to \Bool) \to \Bool$ leads to a contradiction if we assume $\Prop = \Bool$ (classical logic). Assume that $\inn_T : T (\mu\,T) \to \mu\,T$ is an isomorphism
 \footnote{We are going to prove this in the next section.}.
 \emph{Hint:} Derive a retraction, i.e. a function $\phi : (\mu\,T \to \Bool) \to \mu\,T$ that has a left inverse. Show that such a retract cannot exists using Cantor's diagonalisation.
@@ -216,7 +216,7 @@ The lower square commutes due to the definition of $\out_T$, the upper square co
 Hence we have verified that $\inn_T$ and $\out_T$ are an isomorphism.
 
 \section{Streams}
-\label{sec:terminal-coalgebras}
+\label{sec:streams}
 
 The dual of initial algebras, terminal coalgebras, turn out to be useful as well. An example of a coinductive type is the type of streams $\Stream\,A : \Set$ this are infinite sequences of elements of $A:\Set$, that is 
 \begin{align*}
@@ -266,7 +266,7 @@ $\Stream$ is a functor, that is given a function $f:A \to B$ we can define
 \head\,(\Stream\,f\,\vec{a}) & = f\,(\head\,a) \\
 \tail\,(\Stream\,f\,\vec{a}) & = \Stream\,f\,(\tail\,\vec{a})
 \end{align*}
-\begin{exercise}
+\begin{exercise}{}
   Define $\Stream\,f$ using only the coiterator.
 \end{exercise}
 % The dual of induction is coinduction. This is usually formulated using the concept of a bisimulation: A relation 
@@ -297,7 +297,7 @@ We observe that
 \end{align*}
 That is both side are equal to $\CoIt\,\suc\,\suc$ and hence equal due to uniqueness. 
 
-\begin{exercise}
+\begin{exercise}{}
   Prove that $\Stream\,A$ is isomorphic to $\Nat \to A$.
 \end{exercise}
 
@@ -320,19 +320,19 @@ As for algebras, Identity and composition is given by identity and composition i
 
 It is clear that $\Stream\,A$ is the terminal coalgebra of the functor $T_{\Stream\,A}\,X = A \times X$. We can look at initial algebras and terminal coalgebras for the same functor. In the case of $T_{\Stream\,A}$  this is not very interesting because the initial algebra is just the empty set. However, natural numbers $T_\Nat\,X = 1+X$ and lists $T_{\List\,A}\,X = 1 + A \times X$ are more interesting: here the terminal coalgebras are called the conatural numbers and colists: they include both finite elements and infinite elements. 
 
-\begin{exercise}
+\begin{exercise}{}
   Show that the initial algebra of $T_{\Stream\,A}\,X = A \times X$ is isomorphic to the empty set
 \end{exercise}
 
-\begin{exercise}
+\begin{exercise}{}
   Define addition for conatural numbers ($\Nat^\infty = \nu X.1+X$) using only the coiterator.
 \end{exercise}
 
-\begin{exercise}
-  Show explicitely that Lambek's lemma hold for terminal coalgebras.
+\begin{exercise}{}
+  Show explicitly that Lambek's lemma hold for terminal coalgebras.
 \end{exercise}
 
 
-% \begin{exercise}
+% \begin{exercise}{}
 %   Show that there is always a monomorphism from the initial algebra to the terminal coalgebra.
 % \end{exercise}

--- a/chapters/limits-colimits.tex
+++ b/chapters/limits-colimits.tex
@@ -48,7 +48,7 @@ D \arrow[rrd,bend left = 40,"h"] \arrow[ddr,bend right = 40,"k" below]
 &  B \arrow[r,"g" below] &C 
 \end{tikzcd}\]
 
-\begin{exercise}
+\begin{exercise}{}
   What happens if we don't demand $f \circ h = g \circ k$? Can we still obtain $\pair{h}{k} : D \to E$?
 \end{exercise}
 
@@ -61,7 +61,7 @@ My notation for pullbacks is motivated by the observation that pullbacks are act
 \end{tikzcd}\]
 commutes.
 
-\begin{exercise}
+\begin{exercise}{}
   Show that the pullback $f \times_C g$ is the product of $f$ and $g$ in the slice category $\cat{C}/C$.
 \end{exercise}
 
@@ -86,11 +86,11 @@ The universal property is; given any other set $C$ together with a function $h :
   \Eq{f}{g} \arrow[r,"e" below] & A \arrow[r,"f",shift left] \arrow[r,"g" below,shift right]& B 
 \end{tikzcd}\]
 
-\begin{exercise}
+\begin{exercise}{}
   Spell out the definition of an equalizer in an arbitrary category $\cat{C}$
 \end{exercise}
 
-\begin{exercise}
+\begin{exercise}{}
   Show that  $e : \Eq{f}{g} \to A$ is a mono.
 \end{exercise}
 
@@ -128,11 +128,11 @@ we can construct the pullback as the equalizer
 \end{tikzcd}\]
 using $e$ composed with the product projections for the projections of the pullback.
 
-\begin{exercise}
+\begin{exercise}{}
   Carry out the constructions in detail, using only the universal properties.
 \end{exercise}
 
-\begin{exercise}
+\begin{exercise}{}
   Show that we can't get a terminal object from equalizers and binary products.
 \end{exercise}
 % the empty category

--- a/chapters/prod-copr-expon.tex
+++ b/chapters/prod-copr-expon.tex
@@ -62,7 +62,7 @@ As for terminal and initial objects we can show that products are unique up to i
 % do this explicitly?
 
 We have only defined binary products, what about ternary products? There are at least two ways to derive them from binary products $A \times (B\times C)$ and $(A\times B)\times C$. 
-\begin{exercise}
+\begin{exercise}{}
   Show that $A \times (B\times C) \cong (A\times B)\times C$. 
 \end{exercise}
 \begin{answer}
@@ -126,7 +126,7 @@ This is the unique function which makes the following diagram commute:
 A \arrow[r,"\inj_1" below] \arrow[ur,"f"] & A + B \arrow[u,dashrightarrow,"\case{f}{g}" right] & B \arrow[l,"\inj_2"] \arrow[ul,"g" above]
 \end{tikzcd}\]
 Moreover this assignment is natural, i.e. $h \circ \case{f}{g} = \case{h\circ f}{h\circ g}$.
-\begin{exercise}
+\begin{exercise}{}
   Verify uniqueness and naturality of $\case{f}{g}$.
 \end{exercise}
 
@@ -146,7 +146,7 @@ Moreover this assignment is natural, i.e. $h \circ \case{f}{g} = \case{h\circ f}
 As for produts we say that a category has all finite coproducts if it has an initial object and all binary coproducts.
 
 In $\Set$ and actually in many categories products and coproducts are very different, but this is not always the case. We have already seen that in $\cat{Mon}$ ths initial object and the terminal object coincide. For the following consider the category of commutative monoids $\cat{CMon}$ which is like monoids but with the additional property that $x * y = y * x$ for any object $(A,e,\_*\_)$. Given two commutative monoids  $(A,e,\_*\_),  (B,z,\_+\_)$ we define $A \oplus B$ as $(A\times B,(e,z),\_ \bullet \_)$ where $(a,b) \bullet (a',b') = (a * a',b + b')$. It is easy to see that this is a commutative monoid again.
-\begin{exercise}
+\begin{exercise}{}
 Show that $A \oplus B$ is both a product and a coproduct of $A$ and $B$.
 \end{exercise}
 \begin{answer}
@@ -204,7 +204,7 @@ Show that $A \oplus B$ is both a product and a coproduct of $A$ and $B$.
 Products and coproducts can also be defined as an adjunction: Given a category $\cat{C}$ we write $\cat{C^2} = \cat{C}\times\cat{C}$
 \footnote{Yes, this is a product in the category of categories which is not a category in our sense. We already develop a taste for higher categories\dots}
 whose objects are pairs of objects and whose morphsims are pairs of morphisms in $\cat{C}$. There is a functor $\Delta : \cat{C} \to \cat{C^2}$ (called the diagonal functor) which just copies, that is $\Delta\,A = (A,A)$ and the same on morphisms. Now if $\cat{C}$ has binary products and coproducts resepctively we also have $\_\times\_, \_+\_ : \cat{C^2} \to \cat{C}$
-\begin{exercise}
+\begin{exercise}{}
   Define the morphism parts of these functors using only the properties of products / coproducts.
 \end{exercise}
 Moreover, they are left and right adjoint to $\Delta$:
@@ -212,7 +212,7 @@ Moreover, they are left and right adjoint to $\Delta$:
 \cat{C} \arrow[d,"\Delta" near start] \\ 
 \cat{C^2} \arrow[u,bend left = 60,"\_+\_" left,"\dashv" right=5 ] \arrow[u,bend right = 60,"\_\times\_" right,"\dashv" left = 5]
 \end{tikzcd}\]
-\begin{exercise}
+\begin{exercise}{}
   Verify these adjunctions, i.e. show that
   \begin{align*}
     \cat{C}(X,Z) \times \cat{C}(Y,Z) \cong \cat{C}(X + Y,Z) \\
@@ -235,11 +235,11 @@ where
   &\psi_{A,B,C} : (A\to(B \to C)) \to (A\times B \to C) \\
   &\psi\,g = \lambda p.g\,(\pi_1\,p)\,(\pi_2\,p)
 \end{align*}
-\begin{exercise}
+\begin{exercise}{}
   Verify that $\phi$ and $\psi$ are inverse to each other.
 \end{exercise}
 If we fix $B$ this looks like an adjunction, namely the functors $\_\times B, B \to \_ : \Set \to \Set$ form an adjunction. All that is left is to check naturality:
-\begin{exercise}
+\begin{exercise}{}
   Derive the morphism part of $\_\times B$ and $B \to \_$ and
   check that $\phi_{A,B,C}$ is natural in $A,C$, that is given $f : A \to A'$ and $g : C \to C'$
 \[\begin{tikzcd}[row sep = large]
@@ -251,7 +251,7 @@ If we fix $B$ this looks like an adjunction, namely the functors $\_\times B, B 
 This directly leads to the definition of \emph{exponentials (aka function objects)} for a category $\cat{C}$ with products, we say that for a fixed object $B:\obj{\cat{C}}$ an exponential $\expC{}{B}{\_}$ or $(\_)^B$ is the right adjoint to $\_ \times B$. We can compare $\expC{}{\_}{\_}$ with homsets $\homC{C}{\_}{\_}$ both take two objects as input but the first one returns an object while the latter returns a set. This is why exponentials are also called internal homs. Only on $\Set$ the two are actually the same.
 
 By definition $\expC{\cat{C}}{B}{\_}$ is a covariant functor $\cat{C} \to \cat{C}$ but exponentials also give rise to a contravariant functor:
-\begin{exercise}
+\begin{exercise}{}
 Show that $\expC{\cat{C}}{\_}{C}$ is a contravariant functor, i.e. 
 \[\expC{}{\_}{C} : \cat{C}^\op \to \cat{C}.\]     
 \end{exercise}
@@ -278,7 +278,7 @@ exponentials & $m \to n = n^m$\\\hline
 % \item[exponentials] $m^n$.
 % \end{description}
 
-\begin{exercise}
+\begin{exercise}{}
 Verify that these definitions indeed have the required properties.
 \end{exercise}
 
@@ -293,7 +293,7 @@ products & $P \wedge Q$ \\\hline
 exponentials & $P \to Q$\\\hline
 \end{tabular}
 
-\begin{exercise}
+\begin{exercise}{}
 Verify that these definitions indeed have the required properties.
 \end{exercise}
 A bicartesian closed category which is a preorder is called a \emph{Heyting algebra}, it is a model for intuitionistic propositional logic.
@@ -325,7 +325,7 @@ The easiest way to show this is to use the corollary from the Yoneda lemma: to s
 \end{align*}
 and hence $(B + C)\times A \cong B\times A + C \times A$.
 In each line we only used the adjunctions defining $\times$, $+$ and $\expC{}{}{}$.
-\begin{exercise}
+\begin{exercise}{}
   Prove the first isomorphism $0 \times A \cong 0$ using the same idea. Note that $\homC{C}{0}{A} \cong 1$
 \end{exercise}
 
@@ -337,7 +337,7 @@ A & \cong 1 \times A \\
 \end{align*}
 But this is certainly not true in $\cat{Mon}$, hence we can conclude that $\cat{Mon}$ is not cartesian closed. 
 
-\begin{exercise}
+\begin{exercise}{}
   Is $\cat{\omega}$ (bi)cartesian closed? What about $\cat{\omega}^\op$?
 \end{exercise}
 
@@ -346,7 +346,7 @@ An important example for a bicartesian closed category is the category of preshe
   (F \times G)\,A = F\,A \times G\,A \\
   (F + G)\, A = F\,A + G\,A
 \end{align*}
-\begin{exercise}
+\begin{exercise}{}
   Verify that these are indeed products and coproducts in $\PSh\,\cat{C}$.
 \end{exercise}
 
@@ -365,7 +365,7 @@ So the last line is a candidate for the exponential but in this case we do need 
 (\expC{\PSh\,\cat{C}}{F}{G})\,A & = \int_{X:\cat{C}}C(X,A)\to F\,X \to G\,X
 \end{align*}
 % We also need to check that this definition actually satisfies the universal property:
-% \begin{exercise}
+% \begin{exercise}{}
 %   Show that the above definition of $\expC{\PSh\,\cat{C}}{F}{G}$ satisfies the universal property of exponentials, i.e. for $H : \PSh\,\cat{C}$
 %   \[ \PSh\,\cat{C}(H \times F,G) \simeq \PSh\,\cat{C}(H, \ex But what about exponentials? We cannot have $(\expC{\PSh\,\cat{C}}{F}{G})\,A = F\,A \to G\,A$ because this wouldn't be a contravariant functor since $F$ appears on the left hand side of the exponential. The construction of the exponential is actually a nice application of the Yoneda lemma: 
 % If we assume that the exponential exists we have then 
@@ -382,7 +382,7 @@ So the last line is a candidate for the exponential but in this case we do need 
 % (\expC{\PSh\,\cat{C}}{F}{G})\,A & = \int_{X:\cat{C}}C(X,A)\to F\,X \to G\,X)
 % \end{align*}
 We also need to check that this definition actually satisfies the universal property:
-\begin{exercise}
+\begin{exercise}{}
   Show that the above definition of $\expC{\PSh\,\cat{C}}{F}{G}$ satisfies the universal property of exponentials, i.e. for $H : \PSh\,\cat{C}$
   \[ \PSh\,\cat{C}(H \times F,G) \simeq \PSh\,\cat{C}(H, \expC{\PSh\,\cat{C}}{F}{G})\]
   i.e.
@@ -397,7 +397,7 @@ Given a preorder, that is $|R|:\Set$ and $\_R\_ : |R| \to |R| \to \Prop$ that is
 This is a bicartesian closed category the constructions are simplified versions of the ones for set valued presehaves, in particular 
 \[(\expX{P}{Q})\,x = \forall y:|R|.y\,R\,x\to P\,y \to Q\,y \]
 These categories are called \emph{Kripke models} and the fact that they are bicartesian closed corresponds to the fact that they model intuitionistic propositional logic.
-\begin{exercise}
+\begin{exercise}{}
   Use Kripke models to show that the law of the excluded middle $P \vee \neg P$ is not derivable in intuitionistic logic. 
 \end{exercise}
 
@@ -411,7 +411,7 @@ natural in $C$.
 
 An example for such a \emph{symmetric cartesian closed category} is the category of booleans which is similar to the category of propositions, but we use booleans instead of propositions. In particular, the type of objects is $\Bool$ and the homsets are given as 
 $\homC{\Bool}{p}{q} = \T\,p \to \T\,q$ where $\T : \Bool \to \Prop$ is defined as $\T\,b = (b = \true)$. We can define products, coproducts and exponentials as for $\Prop$, i.e. by using the usual truthtable semantics. Subtraction can be defines as $p-q = p \wedge \neg q$.
-\begin{exercise}
+\begin{exercise}{}
   Check that $\cat{\Bool}$ is a symmetric cartesian closed category.
 \end{exercise}
 You may notice that this example is a preorder. This is no accident because all symmetric cartesian closed categories are preorders. This is because in such a category also the dual form of distributivity hold:
@@ -420,11 +420,11 @@ You may notice that this example is a preorder. This is no accident because all 
   (B \times C) + A & \cong (B + A) \times (C + A)
 \end{align*}
 The first one is already suspicious because it implies in particular that $1+1 = 1$, which basically says that $\true = \false$ in $\Bool$. Moreover:
-\begin{exercise}
+\begin{exercise}{}
   In a bicartesian closed category with $1 = 1+1$ all morphisms are equal (i.e. it is a preorder). 
 \end{exercise}
 You may wonder wether symmetry already implies excluded middle $P \vee \neg P$, which certainly holds in $\cat{\Bool}$. The answer is no, because we can extend Kripke semantics to the symmetric logic (using boolean valued presheaves over finite preorders) and uses this to show that excluded middle isn't implied. 
 
-\begin{exercise}
+\begin{exercise}{}
   Show that the category $\cat{1+\omega}$ is a symmetric cartesian closed category. It's definition is similar to $\cat{\omega}$ its objects are the natural numbers and a top element $\omega$ such that $i \leq \omega$ for all elements.
 \end{exercise}

--- a/preamble.sty
+++ b/preamble.sty
@@ -30,8 +30,11 @@
 \usepackage{mathtools}
 \usepackage{enumitem}
 \usepackage{framed}
+\usepackage{xifthen}
 
-
+\newcommand{\ifnonempty}[2]{%
+  \ifthenelse{\isempty{#1}}{}{#2}%
+}
 
 
 \renewcommand{\ExerciseHeader}{{\noindent\textbf{
@@ -40,6 +43,7 @@
 \renewcommand{\AnswerHeader}{\noindent{\textbf{Exercise\ \ExerciseHeaderNB:}}\;}
 \renewcommand{\ExerciseSkipAfter}{8pt}
 \renewcommand{\AnswerSkipAfter}{8pt}
+\newcommand{\Exerciseautorefname}{Exercise}
 
 \newtheorem{question}[Exercise]{Question}
 
@@ -87,10 +91,11 @@
 }{}{}
 
 % Saves the problem statement to theproblem.tmp, and prints it in an Exercise environment
-\newenvironment{exercise}
+\NewDocumentEnvironment{exercise}{m}
 {\VerbatimOut{theproblem.tmp}}
 {\endVerbatimOut
-  \begin{Exercise}
+  \begin{Exercise}[label=#1] 
+
     \input{theproblem.tmp}
   \end{Exercise}
 }
@@ -124,7 +129,7 @@
   \begin{figure}[t] \label{checklist:#2}
     \begin{framed}
       \begin{center}
-      \textbf{#2~checklist}\ifx{#1}{}{}\else{:~#1}\fi
+      \textbf{#2~checklist}\ifnonempty{#1}{:~#1}
       \vspace{0.25cm}
       \hrule
       \vspace{0.25cm}
@@ -141,7 +146,7 @@
 \newenvironment{DoubleChecklist}[2][]{
   \begin{figure}[t] \label{checklist:#2}
     \begin{framed} \centering
-    \textbf{#2~checklist}\ifx{#1}{}{}\else{:~#1}\fi
+    \textbf{#2~checklist}\ifnonempty{#1}{:~#1}
     \vspace{0.25cm}
     \hrule
     \vspace{0.25cm}
@@ -161,7 +166,7 @@
       \begin{center}\itshape #4\end{center}
       \begin{checklist}}
     \begin{framed} \centering
-    \textbf{#2~checklist}\ifx{#1}{}{}\else{:~#1}\fi
+    \textbf{#2~checklist}\ifnonempty{#1}{:~#1}
     \vspace{0.25cm}
     \hrule
     \vspace{0.25cm}

--- a/preamble.sty
+++ b/preamble.sty
@@ -27,6 +27,9 @@
 \usepackage{etoolbox}
 \usetikzlibrary{cd}
 \usepackage{minted}
+\usepackage{mathtools}
+\usepackage{enumitem}
+\usepackage{framed}
 
 
 
@@ -109,3 +112,68 @@
     \noindent\textit{Solution:}
     
 }{\end{Answer}}
+
+\newcommand{\checkbox}{$\Box$}
+\newcommand{\checked}{\raisebox{-.7pt}{\rlap{$\Box$}\;\!\raisebox{1.4pt}{\checkmark}}}
+\newlist{checklist}{itemize}{3}
+\setlist{noitemsep}
+\setlist[checklist]{label={\checkbox}}
+
+
+\newenvironment{Checklist}[2][]{
+  \begin{figure}[t] \label{checklist:#2}
+    \begin{framed}
+      \begin{center}
+      \textbf{#2~checklist}\ifx{#1}{}{}\else{:~#1}\fi
+      \vspace{0.25cm}
+      \hrule
+      \vspace{0.25cm}
+    
+    \begin{checklist}
+}
+{
+    \end{checklist}
+\end{center}
+\end{framed}
+\end{figure}
+}
+\newcommand{\NextColumn}{\end{checklist}\end{minipage}\begin{minipage}[t]{0.49\textwidth}\begin{checklist}}
+\newenvironment{DoubleChecklist}[2][]{
+  \begin{figure}[t] \label{checklist:#2}
+    \begin{framed} \centering
+    \textbf{#2~checklist}\ifx{#1}{}{}\else{:~#1}\fi
+    \vspace{0.25cm}
+    \hrule
+    \vspace{0.25cm}
+    \begin{minipage}[t]{0.49\textwidth}
+    \begin{checklist}
+}
+{
+    \end{checklist}
+  \end{minipage}
+\end{framed}
+\end{figure}
+}
+
+\newenvironment{NamedDoubleChecklist}[4][]{
+  \begin{figure}[t] \label{checklist:#2}
+    \renewcommand{\NextColumn}{\end{checklist}\end{minipage}\begin{minipage}[t]{0.49\textwidth}
+      \begin{center}\itshape #4\end{center}
+      \begin{checklist}}
+    \begin{framed} \centering
+    \textbf{#2~checklist}\ifx{#1}{}{}\else{:~#1}\fi
+    \vspace{0.25cm}
+    \hrule
+    \vspace{0.25cm}
+    \begin{minipage}[t]{0.49\textwidth}
+      \begin{center}\itshape #3\end{center}
+    \begin{checklist}
+}
+{
+    \end{checklist}
+  \end{minipage}
+\end{framed}
+\end{figure}
+}
+
+\newcommand{\checklistref}[1]{\hyperref[checklist:#1]{#1~checklist}}


### PR DESCRIPTION
Creates environments for checklist figures.

- `\checkbox` and `\checked` macros
- `Checklist` accepts 2 arguments: `#1` is an optional caption, and `#2` is the title of the checklist. Formats a figure with a single-column checklist
- `DoubleChecklist` accepts the same 2 arguments, and formats a 2-column checklist. Midway through the checklist, the command `\NextColumn` should be used to divide the two halves. E.g.
```latex
\begin{DoubleChecklist}{My Checklist}
    \item Left column, item 1
    \item Left column, item 2
    \NextColumn
    \item Right column, item 1
\end{DoubleChecklist}
```
- `NamedDoubleChecklist` is like `DoubleChecklist`, but accepts two more arguments, which are formatted as the headers of the two columns. E.g.
```latex
\begin{NamedDoubleChecklist}[to define a category $\cat{C}$, we need to specify]{Category}{Data}{Conditions}
  \item objects
  \item homsets (morphisms)
  \item identity morphisms
  \item composition

  \NextColumn

  \item identity is neutral (left and right)
  \item composition is associative
\end{NamedDoubleChecklist}
```
is rendered
![image](https://github.com/user-attachments/assets/138e607f-5796-4e77-ab16-75763d187ca9)
